### PR TITLE
SerialPortの解放忘れの修正

### DIFF
--- a/include/layered_hardware_unitree/unitree_actuator_data.hpp
+++ b/include/layered_hardware_unitree/unitree_actuator_data.hpp
@@ -1,21 +1,19 @@
 #ifndef LAYERED_HARDWARE_UNITREE_UNITREE_ACTUATOR_DATA_HPP
 #define LAYERED_HARDWARE_UNITREE_UNITREE_ACTUATOR_DATA_HPP
 
-#include <memory>
 #include "serialPort/SerialPort.h"
 #include "unitreeMotor/unitreeMotor.h"
+#include <memory>
 
 namespace layered_hardware_unitree {
 
 struct UnitreeActuatorData {
-  UnitreeActuatorData(const std::string &_name, SerialPort *const _serial,
-                      const std::uint8_t _id, const MotorType &_motor_type, 
-                      const std::vector<double> &_torque_limits, const int &_temp_limit,
+  UnitreeActuatorData(const std::string &_name, const std::shared_ptr< SerialPort > &_serial,
+                      const std::uint8_t _id, const MotorType &_motor_type,
+                      const std::vector< double > &_torque_limits, const int &_temp_limit,
                       const double &_pos_gain, const double &_vel_gain)
-      : name(_name), m_cmd(), m_data(), serial(_serial), id(_id),
-        torque_limits(_torque_limits), 
-        motor_type(_motor_type), temp_limit(_temp_limit),
-        pos_gain(_pos_gain), vel_gain(_vel_gain),
+      : name(_name), m_cmd(), m_data(), serial(_serial), id(_id), torque_limits(_torque_limits),
+        motor_type(_motor_type), temp_limit(_temp_limit), pos_gain(_pos_gain), vel_gain(_vel_gain),
         pos(0.), vel(0.), eff(0.), temperature(0), pos_cmd(0.), vel_cmd(0.), eff_cmd(0.) {
     // initialize motor command & state
     m_cmd.motorType = motor_type;
@@ -32,18 +30,17 @@ struct UnitreeActuatorData {
     m_data.motorType = motor_type;
   }
 
-
   // handles
   const std::string name;
   MotorCmd m_cmd;
   MotorData m_data;
-  SerialPort *const serial;
+  const std::shared_ptr< SerialPort > serial;
   const std::uint8_t id;
 
   // params
   MotorType motor_type;
   const int temp_limit;
-  const std::vector<double> torque_limits;
+  const std::vector< double > torque_limits;
   const double pos_gain, vel_gain;
 
   // states

--- a/include/layered_hardware_unitree/unitree_actuator_layer.hpp
+++ b/include/layered_hardware_unitree/unitree_actuator_layer.hpp
@@ -1,6 +1,7 @@
 #ifndef LAYERED_HARDWARE_UNITREE_UNITREE_ACTUATOR_LAYER_HPP
 #define LAYERED_HARDWARE_UNITREE_UNITREE_ACTUATOR_LAYER_HPP
 
+#include <memory>
 
 #include <layered_hardware/layer_base.hpp>
 #include <layered_hardware_unitree/common_namespaces.hpp>
@@ -31,9 +32,8 @@ public:
     // open USB serial device
     std::string port = param< std::string >(param_nh, "serial_interface", "/dev/ttyUSB0");
     try {
-      serial_ = new SerialPort(port);
-    }
-    catch(IOException& e) {
+      serial_ = std::make_shared< SerialPort >(port);
+    } catch (IOException &e) {
       ROS_ERROR_STREAM("UnitreeActuatorLayer::init(): Failed to open SerialPort: " << e.what());
       return false;
     }
@@ -46,8 +46,8 @@ public:
       return false;
     }
     if (ators_param.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
-      ROS_ERROR_STREAM("UnitreeActuatorLayer::init(): Param '"
-                       << param_nh.resolveName("actuators") << "' must be a struct");
+      ROS_ERROR_STREAM("UnitreeActuatorLayer::init(): Param '" << param_nh.resolveName("actuators")
+                                                               << "' must be a struct");
       return false;
     }
 
@@ -59,9 +59,9 @@ public:
       if (!ator->init(ator_param.first, serial_, hw, ator_param_nh)) {
         return false;
       }
-      ROS_INFO_STREAM("UnitreeActuatorLayer::init(): Initialized the actuator '"
-                      << ator_param.first << "'");
-      actuators_.push_back(ator);      
+      ROS_INFO_STREAM("UnitreeActuatorLayer::init(): Initialized the actuator '" << ator_param.first
+                                                                                 << "'");
+      actuators_.push_back(ator);
     }
 
     return true;
@@ -79,7 +79,7 @@ public:
       }
     }
 
-    return true;                            
+    return true;
   }
 
   virtual void doSwitch(const std::list< hi::ControllerInfo > &start_list,
@@ -118,7 +118,7 @@ private:
   }
 
 private:
-  SerialPort* serial_;
+  std::shared_ptr< SerialPort > serial_;
   ControllerSet controllers_;
   std::vector< UnitreeActuatorPtr > actuators_;
 };


### PR DESCRIPTION
`SerialPort`オブジェクトを生ポインタでなく`std::shared_ptr<>`で管理するようにしました．これにより，誰も`shared_ptr`を参照しなくなったタイミングで`SerialPort`オブジェクトが破棄されます．言い換えれば，使用者のいなくなったタイミングで`SerialPort`のデストラクタが呼び出され，（unitree_sdkの実装しだいだが）シリアルポートが閉じられます．

なお，これまでは`new SerialPort()`でコンストラクトしたものの`delete`していなかったため，シリアルポートが閉じられていませんでした．プロセスの終了後，使われていないシリアルポートをOSが発見して閉じていたために問題が顕在化していなかったのだと想像します．別の環境で実行したり，プロセスをすぐに立ち上げ直した場合などは，シリアルポートを別プロセスが占有しているため開けないエラーが発生するおそれがありました．