### PR TITLE
Github Actionsによるビルドチェックの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - add-ci-build-check
+      - main
 jobs:
   ci:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+on:
+  push:
+    branches:
+      - add-ci-build-check
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+      image: ros:noetic-ros-base
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # System update
+      - name: Run apt-upgrade
+        run: |
+          sudo apt update
+          sudo apt --yes upgrade
+      # Checkout core
+      - name: Checkout layered_hardware
+        uses: actions/checkout@v2
+        with:
+          repository: yoshito-n-students/layered_hardware
+          path: src/layered_hardware
+      # Checkout extensions
+      - name: Checkout layered_hardware_extensions
+        uses: actions/checkout@v2
+        with:
+          repository: yoshito-n-students/layered_hardware_extensions
+          path: src/layered_hardware_extensions
+      # Checkout dynamixel
+      - name: Checkout layered_hardware_unitree
+        uses: actions/checkout@v2
+        with:
+          repository: yoshito-n-students/layered_hardware_unitree
+          path: src/layered_hardware_unitree
+      # Checkout misc
+      - name: Checkout ros_controll_extensions
+        uses: actions/checkout@v2
+        with:
+          repository: yoshito-n-students/ros_control_extensions
+          path: src/ros_control_extensions
+      # Install dependencies
+      - name: Run rosdep-install
+        run: |
+          source /opt/ros/noetic/setup.bash
+          sudo apt update
+          rosdep update --rosdistro noetic
+          sudo rosdep install --default-yes -r --ignore-src --from-paths src --rosdistro noetic
+      # catkin_make
+      - name: Build
+        run: |
+          source /opt/ros/noetic/setup.bash
+          catkin_make
+      # run_tests
+      - name: Run tests
+        run: |
+          source /opt/ros/noetic/setup.bash
+          catkin_make run_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt --yes upgrade
-          sudo apt install git
+          sudo apt install -y git
       # Checkout core
       - name: Checkout layered_hardware
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,26 +21,26 @@ jobs:
           sudo apt --yes upgrade
       # Checkout core
       - name: Checkout layered_hardware
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: yoshito-n-students/layered_hardware
           path: src/layered_hardware
       # Checkout extensions
       - name: Checkout layered_hardware_extensions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: yoshito-n-students/layered_hardware_extensions
           path: src/layered_hardware_extensions
       # Checkout dynamixel
       - name: Checkout layered_hardware_unitree
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: yoshito-n-students/layered_hardware_unitree
           path: src/layered_hardware_unitree
           submodules: true
       # Checkout misc
       - name: Checkout ros_controll_extensions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: yoshito-n-students/ros_control_extensions
           path: src/ros_control_extensions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt --yes upgrade
+          sudo apt install git
       # Checkout core
       - name: Checkout layered_hardware
         uses: actions/checkout@v4
@@ -37,10 +38,7 @@ jobs:
         with:
           repository: yoshito-n-students/layered_hardware_unitree
           path: src/layered_hardware_unitree
-      - name: Submodule update
-        run: |
-          cd src/layered_hardware_unitree
-          git submodule update --init
+          submodules: true
       # Checkout misc
       - name: Checkout ros_controll_extensions
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           repository: yoshito-n-students/layered_hardware_unitree
           path: src/layered_hardware_unitree
+          submodules: true
       # Checkout misc
       - name: Checkout ros_controll_extensions
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
         with:
           repository: yoshito-n-students/layered_hardware_unitree
           path: src/layered_hardware_unitree
-          submodules: true
+          run: |
+            cd src/layered_hardware_unitree
+            git submodule update --init
       # Checkout misc
       - name: Checkout ros_controll_extensions
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,16 @@ jobs:
         with:
           repository: yoshito-n-students/layered_hardware_extensions
           path: src/layered_hardware_extensions
-      # Checkout dynamixel
+      # Checkout unitree
       - name: Checkout layered_hardware_unitree
         uses: actions/checkout@v4
         with:
           repository: yoshito-n-students/layered_hardware_unitree
           path: src/layered_hardware_unitree
-          run: |
-            cd src/layered_hardware_unitree
-            git submodule update --init
+      - name: Submodule update
+        run: |
+          cd src/layered_hardware_unitree
+          git submodule update --init
       # Checkout misc
       - name: Checkout ros_controll_extensions
         uses: actions/checkout@v4


### PR DESCRIPTION
`main`ブランチにpushがあった際に，最小限のROS Noetic環境に`layered_hardware`系パッケージをcloneし，`rosdep`によって依存パッケージをインストールし，Github上で`catkin_make`を実行し，ビルドが通るかチェックするようにしました．コードのミスだけでなく，パッケージの依存関係の宣言ミスや，他の人の環境でビルドできない系の問題を発見できます．