### PR TITLE
フォーマット定義ファイルの追加

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+ColumnLimit: 100
+SpacesInAngles: true


### PR DESCRIPTION
`.clang-format`ファイルを追加しました．これにはコードの整形ルールが書かれており，コマンドラインやVSCodeでコードの自動整形ができるようになります．誰がどこでやっても同じルールを適用できるので，複数環境/複数人での開発に便利です．

現状の`.clang-format`ファイルはほぼデフォルトのルールです．他の`layered_hardware`系のパッケージも同じルールを使っています．include文をファイル名順に並び変えたり，インデントを揃えたり，1行が長い場合に改行したりしてくれます．