### PR TITLE
Operating mode周りのリファクタ

### DIFF
--- a/include/layered_hardware_unitree/operating_mode_base.hpp
+++ b/include/layered_hardware_unitree/operating_mode_base.hpp
@@ -14,9 +14,9 @@ namespace layered_hardware_unitree {
 
 class OperatingModeBase {
 public:
-  OperatingModeBase(const std::string &name, const UnitreeActuatorDataPtr &data) 
+  OperatingModeBase(const std::string &name, const UnitreeActuatorDataPtr &data)
       : name_(name), data_(data) {}
-    
+
   virtual ~OperatingModeBase() {}
 
   std::string getName() const { return name_; }
@@ -29,109 +29,6 @@ public:
   virtual void write(const ros::Time &time, const ros::Duration &period) = 0;
 
   virtual void stopping() = 0;
-
-  void setCmdZero() {
-    data_->m_cmd.kp = 0.;
-    data_->m_cmd.kd = 0.;
-    data_->m_cmd.q = 0.;
-    data_->m_cmd.dq = 0.;
-    data_->m_cmd.tau = 0.;    
-  }
-
-  void torqueOff() {
-    setCmdZero();
-    sendRecv();
-  }
-
-  void setBrakeMode() {
-    data_->m_cmd.mode = queryMotorMode(data_->m_cmd.motorType, MotorMode::BRAKE);
-  }
-
-  void setFOCMode() {
-    data_->m_cmd.mode = queryMotorMode(data_->m_cmd.motorType, MotorMode::FOC);
-  }
-
-  void setPosition(const double& pos, const double& kp) {
-    setCmdZero();
-    data_->m_cmd.kp = kp;
-    data_->m_cmd.q = pos * queryGearRatio(data_->motor_type);
-  }
-
-  void setPosition(const double& pos) {
-    setPosition(pos, data_->pos_gain);
-  }
-
-  void setVelocity(const double& vel, const double& kd) {
-    setCmdZero();
-    data_->m_cmd.kd = kd;
-    data_->m_cmd.dq = vel * queryGearRatio(data_->m_cmd.motorType);
-  }
-
-  void setVelocity(const double& vel) {
-    setVelocity(vel, data_->vel_gain);
-  }
-
-  // double clampTorque(const double& eff) {
-
-  //   return data_->torque_limit < abs(eff) && hasTorqueLimit() ? 
-  //            data_->torque_limit * eff / abs(eff) : eff;
-  // }
-
-  void setTorque(const double& eff) {
-    setCmdZero();
-    data_->m_cmd.tau = eff;
-  }
-
-  bool hasTemperatureLimit() {
-    return data_->temp_limit != 0;
-  }
-
-  bool hasTorqueLimit() {
-    return data_->torque_limits.size() > 1;
-  }
-
-  bool isCommandZero() {
-    return data_->m_cmd.kp == 0. && 
-           data_->m_cmd.kd == 0. &&
-           data_->m_cmd.q == 0. && 
-           data_->m_cmd.dq == 0. &&
-           data_->m_cmd.tau == 0.;            
-  }
-
-  void sendRecv() {
-    data_->serial->sendRecv(&data_->m_cmd, &data_->m_data);
-  }
-
-  struct PosStamp {
-    double pos;
-    ros::Time stamp;
-  };
-
-  void readAllStates() {
-    data_->pos = data_->m_data.q / queryGearRatio(data_->motor_type);
-    // 最小時間10msの角度とタイムスタンプを記録し，記録されたデータから速度を算出する
-    static std::vector<PosStamp> pos_stamps;
-    pos_stamps.push_back({data_->pos, ros::Time::now()});
-    if (pos_stamps.size() > 1 && (pos_stamps.back().stamp - pos_stamps.front().stamp).toSec() > 0.01) {
-      data_->vel = (pos_stamps.back().pos - pos_stamps.front().pos) / ((pos_stamps.back().stamp - pos_stamps.front().stamp).toSec());
-      pos_stamps.erase(pos_stamps.begin());
-    }
-    else if (pos_stamps.size() <= 1) {
-      data_->vel = data_->m_data.dq;
-    }
-
-    data_->eff = data_->m_data.tau;
-    data_->temperature = data_->m_data.temp;
-  }
-
-  //
-  // utility
-  //
-
-  static bool areNotEqual(const double a, const double b) {
-    // does !(|a - b| < EPS) instead of (|a - b| >= EPS) to return True when a and/or b is NaN
-    return !(std::abs(a - b) < std::numeric_limits< double >::epsilon());
-  }
 
 protected:
   const std::string name_;

--- a/include/layered_hardware_unitree/position_mode.hpp
+++ b/include/layered_hardware_unitree/position_mode.hpp
@@ -45,6 +45,7 @@ public:
     data_->eff = data.tau;
     data_->vel = data.dq / ratio;
     data_->pos = data.q / ratio;
+    data_->temperature = data.temp;
   }
 
   virtual void stopping() override {

--- a/include/layered_hardware_unitree/position_mode.hpp
+++ b/include/layered_hardware_unitree/position_mode.hpp
@@ -2,66 +2,59 @@
 #define LAYERED_HARDWARE_UNITREE_POSITION_MODE_HPP
 
 #include <cmath>
-#include <cstdint>
-#include <limits>
-#include <map>
-#include <string>
 
-#include <layered_hardware_unitree/common_namespaces.hpp>
-#include <layered_hardware_unitree/unitree_actuator_data.hpp>
 #include <layered_hardware_unitree/operating_mode_base.hpp>
+#include <layered_hardware_unitree/sdk_utils.hpp>
+#include <layered_hardware_unitree/unitree_actuator_data.hpp>
 #include <ros/duration.h>
 #include <ros/time.h>
-
-#include <ros/duration.h>
-#include <ros/time.h>
-
-#include <boost/optional.hpp>
-
 
 namespace layered_hardware_unitree {
+
 class PositionMode : public OperatingModeBase {
 public:
-  PositionMode(const UnitreeActuatorDataPtr &data) 
-      : OperatingModeBase("position", data) {}
-    
-  virtual void starting() override {
-    data_->m_cmd.kp = 0.01;
-    data_->m_cmd.q = 0.;
-    sendRecv();
-    readAllStates();
+  PositionMode(const UnitreeActuatorDataPtr &data) : OperatingModeBase("position", data) {}
 
-    data_->pos_cmd = data_->pos;
-    prev_pos_cmd_ = std::numeric_limits< double >::quiet_NaN();    
+  virtual void starting() override {
+    // fetch motor position & use it as initial position command value
+    MotorCmd cmd = initializedMotorCmd(data_->motor_type, data_->id, MotorMode::BRAKE);
+    MotorData data = initializedMotorData(data_->motor_type);
+    data_->serial->sendRecv(&cmd, &data);
+    data_->pos_cmd = data.q / queryGearRatio(data_->motor_type);
   }
 
   virtual void read(const ros::Time &time, const ros::Duration &period) override {
-    // read pos, vel, eff, temp
-    readAllStates();
+    // nothing to do as state variables will be updated in write()
   }
 
   virtual void write(const ros::Time &time, const ros::Duration &period) override {
-    // write goal position if the goal pos or profile velocity have been updated
-    // to make the change affect
-    const bool do_write_pos(!std::isnan(data_->pos_cmd) &&
-                            areNotEqual(data_->pos_cmd, prev_pos_cmd_));
-    if (do_write_pos) {
-      if (data_->temp_limit < data_->temperature) {
-        data_->m_cmd.q = data_->pos;
-      }
-      else {
-        data_->m_cmd.q = data_->pos_cmd;
-      }
-      prev_pos_cmd_ = data_->pos_cmd;
-    }
-    sendRecv();
+    const float ratio = queryGearRatio(data_->motor_type);
+    // build motor command
+    // (if command is NaN, use present position instead. if present position is NaN, use 0)
+    MotorCmd cmd = initializedMotorCmd(data_->motor_type, data_->id, MotorMode::FOC);
+    cmd.kp = data_->pos_gain;
+    cmd.q = (!std::isnan(data_->pos_cmd) ? data_->pos_cmd
+                                         : (!std::isnan(data_->pos) ? data_->pos : 0.)) *
+            ratio;
+    // build motor state data
+    MotorData data = initializedMotorData(data_->motor_type);
+    // send command & receive state
+    data_->serial->sendRecv(&cmd, &data);
+    // TODO: check data.merror here
+    // update state variables
+    data_->eff = data.tau;
+    data_->vel = data.dq / ratio;
+    data_->pos = data.q / ratio;
   }
 
-  virtual void stopping() override { torqueOff(); }
-
-private:
-  double prev_pos_cmd_;
+  virtual void stopping() override {
+    // disable torque by sending zero command
+    MotorCmd cmd = initializedMotorCmd(data_->motor_type, data_->id, MotorMode::FOC);
+    MotorData data = initializedMotorData(data_->motor_type);
+    data_->serial->sendRecv(&cmd, &data);
+  }
 };
-}
+
+} // namespace layered_hardware_unitree
 
 #endif

--- a/include/layered_hardware_unitree/safe_velocity_mode.hpp
+++ b/include/layered_hardware_unitree/safe_velocity_mode.hpp
@@ -1,0 +1,195 @@
+#ifndef LAYERED_HARDWARE_UNITREE_SAFE_VELOCITY_MODE_HPP
+#define LAYERED_HARDWARE_UNITREE_SAFE_VELOCITY_MODE_HPP
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <string>
+
+#include <layered_hardware_unitree/common_namespaces.hpp>
+#include <layered_hardware_unitree/operating_mode_base.hpp>
+#include <layered_hardware_unitree/unitree_actuator_data.hpp>
+#include <ros/duration.h>
+#include <ros/time.h>
+
+namespace layered_hardware_unitree {
+class SafeVelocityMode : public OperatingModeBase {
+public:
+  SafeVelocityMode(const UnitreeActuatorDataPtr &data) : OperatingModeBase("safe_velocity", data) {}
+
+  virtual void starting() override {
+    // initialize motor command & state
+    m_cmd.motorType = data_->motor_type;
+    m_cmd.mode = queryMotorMode(data_->motor_type, MotorMode::BRAKE);
+    m_cmd.id = data_->id;
+
+    // Torque Off
+    m_cmd.tau = 0.;
+    m_cmd.dq = 0.;
+    m_cmd.q = 0.;
+    m_cmd.kp = 0.;
+    m_cmd.kd = 0.;
+
+    m_data.motorType = data_->motor_type;
+
+    m_cmd.kd = 0.01;
+    setFOCMode();
+    sendRecv();
+    readAllStates();
+
+    data_->vel_cmd = data_->vel;
+    prev_vel_cmd_ = std::numeric_limits< double >::quiet_NaN();
+  }
+
+  virtual void read(const ros::Time &time, const ros::Duration &period) override {
+    // read pos, vel, eff, temp
+    readAllStates();
+  }
+
+  virtual void write(const ros::Time &time, const ros::Duration &period) override {
+    // write goal position if the goal pos or profile velocity have been updated
+    // to make the change affect
+
+    bool is_limit = false;
+
+    // torque limit -------------------------------------------------------------
+    // If the torque limit is set and no stop command is currently provided
+    if (hasTorqueLimit() && !is_stopping_) {
+      // If the torque limit trigger is exceeded
+      if (data_->torque_limits[0] < abs(data_->eff)) {
+        // Change the scale of the speed command value given to the motor for each
+        // limit between the current torque value and each limit set
+        for (int i = 1; i < data_->torque_limits.size(); i++) {
+          const int n_limits = data_->torque_limits.size() - 1;
+          if (data_->torque_limits[i - 1] < abs(data_->eff) &&
+              abs(data_->eff) < data_->torque_limits[i]) {
+            double scale = (1 / n_limits) /
+                               (data_->torque_limits[i - 1] - data_->torque_limits[i]) *
+                               (abs(data_->eff) - data_->torque_limits[i - 1]) +
+                           (n_limits - i + 1) / n_limits;
+            setVelocity(data_->vel_cmd * scale);
+            break;
+          }
+        }
+
+        if (data_->torque_limits.back() < abs(data_->eff)) {
+          setVelocity(0.);
+        }
+        is_limit = true;
+      }
+    }
+    // --------------------------------------------------------------------------
+
+    // temperature limit --------------------------------------------------------
+    // if over the temperature limit, stop the motor
+    if (data_->temp_limit < data_->temperature && hasTemperatureLimit()) {
+      setVelocity(0.);
+      is_limit = true;
+    }
+    // --------------------------------------------------------------------------
+
+    const bool do_write_vel(!std::isnan(data_->vel_cmd) && data_->vel_cmd != prev_vel_cmd_ &&
+                            !is_limit);
+    if (do_write_vel) {
+
+      if (data_->vel_cmd == 0 && !is_stopping_) {
+        setPosition(data_->pos);
+        is_stopping_ = true;
+      } else {
+        setVelocity(data_->vel_cmd);
+        is_stopping_ = false;
+      }
+    }
+
+    sendRecv();
+    prev_vel_cmd_ = data_->vel_cmd;
+  }
+
+  virtual void stopping() override { torqueOff(); }
+
+protected:
+  void setCmdZero() {
+    m_cmd.kp = 0.;
+    m_cmd.kd = 0.;
+    m_cmd.q = 0.;
+    m_cmd.dq = 0.;
+    m_cmd.tau = 0.;
+  }
+
+  void torqueOff() {
+    setCmdZero();
+    sendRecv();
+  }
+
+  void setBrakeMode() { m_cmd.mode = queryMotorMode(m_cmd.motorType, MotorMode::BRAKE); }
+
+  void setFOCMode() { m_cmd.mode = queryMotorMode(m_cmd.motorType, MotorMode::FOC); }
+
+  void setPosition(const double &pos, const double &kp) {
+    setCmdZero();
+    m_cmd.kp = kp;
+    m_cmd.q = pos * queryGearRatio(data_->motor_type);
+  }
+
+  void setPosition(const double &pos) { setPosition(pos, data_->pos_gain); }
+
+  void setVelocity(const double &vel, const double &kd) {
+    setCmdZero();
+    m_cmd.kd = kd;
+    m_cmd.dq = vel * queryGearRatio(m_cmd.motorType);
+  }
+
+  void setVelocity(const double &vel) { setVelocity(vel, data_->vel_gain); }
+
+  bool hasTemperatureLimit() { return data_->temp_limit != 0; }
+
+  bool hasTorqueLimit() { return data_->torque_limits.size() > 1; }
+
+  bool isCommandZero() {
+    return m_cmd.kp == 0. && m_cmd.kd == 0. && m_cmd.q == 0. && m_cmd.dq == 0. && m_cmd.tau == 0.;
+  }
+
+  void sendRecv() { data_->serial->sendRecv(&m_cmd, &m_data); }
+
+  struct PosStamp {
+    double pos;
+    ros::Time stamp;
+  };
+
+  void readAllStates() {
+    data_->pos = m_data.q / queryGearRatio(data_->motor_type);
+    // 最小時間10msの角度とタイムスタンプを記録し，記録されたデータから速度を算出する
+    static std::vector< PosStamp > pos_stamps;
+    pos_stamps.push_back({data_->pos, ros::Time::now()});
+    if (pos_stamps.size() > 1 &&
+        (pos_stamps.back().stamp - pos_stamps.front().stamp).toSec() > 0.01) {
+      data_->vel = (pos_stamps.back().pos - pos_stamps.front().pos) /
+                   ((pos_stamps.back().stamp - pos_stamps.front().stamp).toSec());
+      pos_stamps.erase(pos_stamps.begin());
+    } else if (pos_stamps.size() <= 1) {
+      data_->vel = m_data.dq;
+    }
+
+    data_->eff = m_data.tau;
+    data_->temperature = m_data.temp;
+  }
+
+  //
+  // utility
+  //
+
+  static bool areNotEqual(const double a, const double b) {
+    // does !(|a - b| < EPS) instead of (|a - b| >= EPS) to return True when a and/or b is NaN
+    return !(std::abs(a - b) < std::numeric_limits< double >::epsilon());
+  }
+
+private:
+  MotorCmd m_cmd;
+  MotorData m_data;
+  double prev_vel_cmd_;
+  bool is_stopping_;
+};
+} // namespace layered_hardware_unitree
+
+#endif

--- a/include/layered_hardware_unitree/sdk_utils.hpp
+++ b/include/layered_hardware_unitree/sdk_utils.hpp
@@ -14,7 +14,7 @@ static inline MotorType toMotorType(const std::string &str) {
     return MotorType::A1;
   } else if (str == "B1") {
     return MotorType::B1;
-  } else if (str == "GO_M8010_6") {
+  } else if (str == "GO-M8010-6") {
     return MotorType::GO_M8010_6;
   } else {
     throw std::runtime_error("Unknown motor type name \"" + str + "\"");
@@ -28,7 +28,7 @@ static inline std::string toString(const MotorType type) {
   case MotorType::B1:
     return "B1";
   case MotorType::GO_M8010_6:
-    return "GO_M8010_6";
+    return "GO-M8010-6";
   default:
     std::ostringstream msg;
     msg << "Unkown motor type id (" << static_cast< int >(type) << ")";

--- a/include/layered_hardware_unitree/sdk_utils.hpp
+++ b/include/layered_hardware_unitree/sdk_utils.hpp
@@ -1,0 +1,61 @@
+#ifndef LAYERED_HARDWARE_UNITREE_SDK_UTILS_HPP
+#define LAYERED_HARDWARE_UNITREE_SDK_UTILS_HPP
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include <unitreeMotor/unitreeMotor.h>
+
+// conversions between MotorType and std::string
+
+static inline MotorType toMotorType(const std::string &str) {
+  if (str == "A1") {
+    return MotorType::A1;
+  } else if (str == "B1") {
+    return MotorType::B1;
+  } else if (str == "GO_M8010_6") {
+    return MotorType::GO_M8010_6;
+  } else {
+    throw std::runtime_error("Unknown motor type name \"" + str + "\"");
+  }
+}
+
+static inline std::string toString(const MotorType type) {
+  switch (type) {
+  case MotorType::A1:
+    return "A1";
+  case MotorType::B1:
+    return "B1";
+  case MotorType::GO_M8010_6:
+    return "GO_M8010_6";
+  default:
+    std::ostringstream msg;
+    msg << "Unkown motor type id (" << static_cast< int >(type) << ")";
+    throw std::runtime_error(msg.str());
+  }
+}
+
+// generate MotorCmd & MotorData ready for SerialPort::sendRecv()
+
+static inline MotorCmd initializedMotorCmd(const MotorType type, const unsigned short id,
+                                           const MotorMode mode) {
+  MotorCmd cmd;
+  cmd.motorType = type;
+  cmd.id = id;
+  cmd.mode = queryMotorMode(type, mode);
+  cmd.tau = 0.;
+  cmd.dq = 0.;
+  cmd.q = 0.;
+  cmd.kp = 0.;
+  cmd.kd = 0.;
+  return cmd;
+}
+
+static inline MotorData initializedMotorData(const MotorType type) {
+  MotorData data;
+  data.motorType = type;
+  return data;
+}
+
+#endif

--- a/include/layered_hardware_unitree/torque_mode.hpp
+++ b/include/layered_hardware_unitree/torque_mode.hpp
@@ -16,7 +16,7 @@ public:
   TorqueMode(const UnitreeActuatorDataPtr &data) : OperatingModeBase("torque", data) {}
 
   virtual void starting() override {
-    // nothing to do
+    data_->eff_cmd = 0.;
   }
 
   virtual void read(const ros::Time &time, const ros::Duration &period) override {

--- a/include/layered_hardware_unitree/torque_mode.hpp
+++ b/include/layered_hardware_unitree/torque_mode.hpp
@@ -38,6 +38,7 @@ public:
     data_->eff = data.tau;
     data_->vel = data.dq / ratio;
     data_->pos = data.q / ratio;
+    data_->temperature = data.temp;
   }
 
   virtual void stopping() override {

--- a/include/layered_hardware_unitree/torque_mode.hpp
+++ b/include/layered_hardware_unitree/torque_mode.hpp
@@ -2,66 +2,51 @@
 #define LAYERED_HARDWARE_UNITREE_TORQUE_MODE_HPP
 
 #include <cmath>
-#include <cstdint>
-#include <limits>
-#include <map>
-#include <string>
 
-#include <layered_hardware_unitree/common_namespaces.hpp>
-#include <layered_hardware_unitree/unitree_actuator_data.hpp>
 #include <layered_hardware_unitree/operating_mode_base.hpp>
+#include <layered_hardware_unitree/sdk_utils.hpp>
+#include <layered_hardware_unitree/unitree_actuator_data.hpp>
 #include <ros/duration.h>
 #include <ros/time.h>
-
-#include <ros/duration.h>
-#include <ros/time.h>
-
-#include <boost/optional.hpp>
-
 
 namespace layered_hardware_unitree {
+
 class TorqueMode : public OperatingModeBase {
 public:
-  TorqueMode(const UnitreeActuatorDataPtr &data) 
-      : OperatingModeBase("torque", data) {}
-    
-  virtual void starting() override {
-    data_->m_cmd.kd = 0.01;
-    data_->m_cmd.dq = 0.;
-    sendRecv();
-    readAllStates();
+  TorqueMode(const UnitreeActuatorDataPtr &data) : OperatingModeBase("torque", data) {}
 
-    data_->eff_cmd = data_->eff;
-    prev_eff_cmd_ = std::numeric_limits< double >::quiet_NaN();    
+  virtual void starting() override {
+    // nothing to do
   }
 
   virtual void read(const ros::Time &time, const ros::Duration &period) override {
-    // read pos, vel, eff, temp
-    readAllStates();
+    // nothing to do as state variables will be updated in write()
   }
 
   virtual void write(const ros::Time &time, const ros::Duration &period) override {
-    // write goal position if the goal pos or profile torque have been updated
-    // to make the change affect
-    const bool do_write_vel(!std::isnan(data_->eff_cmd) &&
-                            areNotEqual(data_->eff_cmd, prev_eff_cmd_));
-    if (do_write_vel) {
-      if (data_->temp_limit < data_->temperature) {
-        data_->m_cmd.tau = 0.;
-      }
-      else {
-        data_->m_cmd.tau = data_->eff_cmd;
-      }
-      prev_eff_cmd_ = data_->eff_cmd;
-    }
-    sendRecv();
+    const float ratio = queryGearRatio(data_->motor_type);
+    // build motor command
+    // (if command is NaN, use 0 instead)
+    MotorCmd cmd = initializedMotorCmd(data_->motor_type, data_->id, MotorMode::FOC);
+    cmd.tau = (!std::isnan(data_->eff_cmd) ? data_->eff_cmd : 0.);
+    // build motor state data
+    MotorData data = initializedMotorData(data_->motor_type);
+    // send command & receive state
+    data_->serial->sendRecv(&cmd, &data);
+    // TODO: check data.merror here
+    // update state variables
+    data_->eff = data.tau;
+    data_->vel = data.dq / ratio;
+    data_->pos = data.q / ratio;
   }
 
-  virtual void stopping() override { torqueOff(); }
-
-private:
-  double prev_eff_cmd_;
+  virtual void stopping() override {
+    // disable torque by sending zero command
+    MotorCmd cmd = initializedMotorCmd(data_->motor_type, data_->id, MotorMode::FOC);
+    MotorData data = initializedMotorData(data_->motor_type);
+    data_->serial->sendRecv(&cmd, &data);
+  }
 };
-}
+} // namespace layered_hardware_unitree
 
 #endif

--- a/include/layered_hardware_unitree/unitree_actuator.hpp
+++ b/include/layered_hardware_unitree/unitree_actuator.hpp
@@ -13,6 +13,7 @@
 #include <layered_hardware_unitree/controller_set.hpp>
 #include <layered_hardware_unitree/operating_mode_base.hpp>
 #include <layered_hardware_unitree/position_mode.hpp>
+#include <layered_hardware_unitree/safe_velocity_mode.hpp>
 #include <layered_hardware_unitree/sdk_utils.hpp>
 #include <layered_hardware_unitree/torque_mode.hpp>
 #include <layered_hardware_unitree/unitree_actuator_data.hpp>
@@ -268,10 +269,12 @@ private:
   OperatingModePtr makeOperatingMode(const std::string &mode_str) const {
     if (mode_str == "position") {
       return std::make_shared< PositionMode >(data_);
-    } else if (mode_str == "velocity") {
+    } else if (mode_str == "safe_velocity") {
       return std::make_shared< VelocityMode >(data_);
     } else if (mode_str == "torque") {
       return std::make_shared< TorqueMode >(data_);
+    } else if (mode_str == "velocity") {
+      return std::make_shared< SafeVelocityMode >(data_);
     }
     ROS_ERROR_STREAM("UnitreeActuator::makeOperatingMode(): Unknown operating mode name '"
                      << mode_str << " for the actuator '" << data_->name

--- a/include/layered_hardware_unitree/unitree_actuator.hpp
+++ b/include/layered_hardware_unitree/unitree_actuator.hpp
@@ -10,12 +10,13 @@
 #include <hardware_interface_extensions/integer_interface.hpp>
 
 #include <layered_hardware_unitree/common_namespaces.hpp>
-#include <layered_hardware_unitree/operating_mode_base.hpp>
-#include <layered_hardware_unitree/unitree_actuator_data.hpp>
 #include <layered_hardware_unitree/controller_set.hpp>
+#include <layered_hardware_unitree/operating_mode_base.hpp>
 #include <layered_hardware_unitree/position_mode.hpp>
-#include <layered_hardware_unitree/velocity_mode.hpp>
+#include <layered_hardware_unitree/sdk_utils.hpp>
 #include <layered_hardware_unitree/torque_mode.hpp>
+#include <layered_hardware_unitree/unitree_actuator_data.hpp>
+#include <layered_hardware_unitree/velocity_mode.hpp>
 
 #include <ros/console.h>
 #include <ros/duration.h>
@@ -53,12 +54,22 @@ public:
     }
 
     // unitree motor type
-    std::string motor_type;
-    if (!param_nh.getParam("motor_type", motor_type)) {
+    std::string motor_type_str;
+    if (!param_nh.getParam("motor_type", motor_type_str)) {
       ROS_ERROR_STREAM("UnitreeActuator::init(): Failed to get param '"
                        << param_nh.resolveName("motor_type") << "'");
       return false;
-    }    
+    }
+
+    // validate motor type string
+    MotorType motor_type;
+    try {
+      motor_type = toMotorType(motor_type_str);
+    } catch (const std::runtime_error &error) {
+      ROS_ERROR_STREAM("UnitreeActuator::init(): Invalid motor type '" << motor_type_str
+                                                                       << "': " << error.what());
+      return false;
+    }
 
     // find unitree actuator by id
     if (!findMotor(id, motor_type, serial)) {
@@ -67,45 +78,40 @@ public:
       return false;
     }
 
-    // // torque constant from param
-    // double torque_constant;
-    // if (!param_nh.getParam("torque_constant", torque_constant)) {
-    //   ROS_ERROR_STREAM("UnitreeActuator::init(): Failed to get param '"
-    //                    << param_nh.resolveName("torque_constant") << "'");
-    //   return false;
-    // }
-
     // get torque limit from parameter
-    std::vector<double> torque_limits;
+    std::vector< double > torque_limits;
     if (!param_nh.getParam("torque_limits", torque_limits)) {
       ROS_WARN_STREAM("UnitreeActuator::init(): Failed to get param '"
-                       << param_nh.resolveName("torque_limits") << "' so it has no torque limits");
+                      << param_nh.resolveName("torque_limits") << "' so it has no torque limits");
     }
 
     // get temperature limit from parameter
     int temp_limit = 0;
     if (!param_nh.getParam("temperature_limit", temp_limit)) {
       ROS_WARN_STREAM("UnitreeActuator::init(): Failed to get param '"
-                       << param_nh.resolveName("temperature_limit") << "' so it has no temperature limit");
+                      << param_nh.resolveName("temperature_limit")
+                      << "' so it has no temperature limit");
     }
 
     // get position gain from parameter
     double pos_gain = 0.5;
     if (!param_nh.getParam("pos_gain", pos_gain)) {
       ROS_WARN_STREAM("UnitreeActuator::init(): Failed to get param '"
-                       << param_nh.resolveName("pos_gain") << "' so it has use default value: " << pos_gain);
+                      << param_nh.resolveName("pos_gain")
+                      << "' so it has use default value: " << pos_gain);
     }
 
     // get velocity gain from parameter
     double vel_gain = 0.01;
     if (!param_nh.getParam("vel_gain", vel_gain)) {
       ROS_WARN_STREAM("UnitreeActuator::init(): Failed to get param '"
-                       << param_nh.resolveName("vel_gain") << "' so it has use default value: " << vel_gain);
+                      << param_nh.resolveName("vel_gain")
+                      << "' so it has use default value: " << vel_gain);
     }
 
     // allocate data structure
-    data_.reset(new UnitreeActuatorData(name, serial, id, getMotorType(motor_type), torque_limits, temp_limit, pos_gain, vel_gain));
-
+    data_.reset(new UnitreeActuatorData(name, serial, id, motor_type, torque_limits, temp_limit,
+                                        pos_gain, vel_gain));
 
     // register actuator states & commands to corresponding hardware interfaces
     const hi::ActuatorStateHandle state_handle(data_->name, &data_->pos, &data_->vel, &data_->eff);
@@ -120,10 +126,10 @@ public:
     }
 
     // register actuator temperature state to coressponding hardware interfaces
-    if (!registerActuatorTo < hie::Int32StateInterface > (
-          hw, hie::Int32StateHandle(data_->name + "/temperature", &data_->temperature))) {
-      return false;      
-    }    
+    if (!registerActuatorTo< hie::Int32StateInterface >(
+            hw, hie::Int32StateHandle(data_->name + "/temperature", &data_->temperature))) {
+      return false;
+    }
 
     // make operating mode map from ros-controller name to unitree's operating mode
     std::map< std::string, std::string > mode_name_map;
@@ -152,7 +158,7 @@ public:
         return false;
       }
       mode_map_[controller_names] = mode;
-    }    
+    }
 
     return true;
   }
@@ -252,50 +258,25 @@ private:
     return std::vector< std::string >();
   }
 
-  static MotorType getMotorType(const std::string &motor_type_str) {
-    if (motor_type_str == "GO-M8010-6") {
-      return MotorType::GO_M8010_6;
-    }
-    else if (motor_type_str == "A1") {
-      return MotorType::A1;
-    }
-    else if (motor_type_str == "B1") {
-      return MotorType::B1;
-    }
-    return MotorType();
-  }
-
-  static bool findMotor(const int &id, const std::string &motor_type, SerialPort *const serial) {
-    MotorCmd cmd;
-  
-    if (!(motor_type == "GO-M8010-6" || motor_type == "A1" || motor_type == "B1")) {
-      ROS_ERROR_STREAM("Unabled motor type: usage(GO-M8010-6, A1, A1)");
-      return false;
-    }
-    
-    cmd.motorType = getMotorType(motor_type);
-    cmd.mode = queryMotorMode(cmd.motorType, MotorMode::BRAKE);
-    cmd.id = id;
-    MotorData data;
-    data.motorType = getMotorType(motor_type);
+  static bool findMotor(const int &id, const MotorType motor_type, SerialPort *const serial) {
+    MotorCmd cmd = initializedMotorCmd(motor_type, id, MotorMode::BRAKE);
+    MotorData data = initializedMotorData(motor_type);
     serial->sendRecv(&cmd, &data);
     return data.merror == 0;
   }
 
   OperatingModePtr makeOperatingMode(const std::string &mode_str) const {
     if (mode_str == "position") {
-      return std::make_shared<PositionMode>(data_);
-    }
-    else if (mode_str == "velocity") {
-      return std::make_shared<VelocityMode>(data_);     
-    }
-    else if (mode_str == "torque") {
-      return std::make_shared<TorqueMode>(data_);
+      return std::make_shared< PositionMode >(data_);
+    } else if (mode_str == "velocity") {
+      return std::make_shared< VelocityMode >(data_);
+    } else if (mode_str == "torque") {
+      return std::make_shared< TorqueMode >(data_);
     }
     ROS_ERROR_STREAM("UnitreeActuator::makeOperatingMode(): Unknown operating mode name '"
                      << mode_str << " for the actuator '" << data_->name
                      << "' (id: " << static_cast< int >(data_->id) << ")");
-    return OperatingModePtr();   
+    return OperatingModePtr();
   }
 
 private:

--- a/include/layered_hardware_unitree/unitree_actuator_data.hpp
+++ b/include/layered_hardware_unitree/unitree_actuator_data.hpp
@@ -1,49 +1,29 @@
 #ifndef LAYERED_HARDWARE_UNITREE_UNITREE_ACTUATOR_DATA_HPP
 #define LAYERED_HARDWARE_UNITREE_UNITREE_ACTUATOR_DATA_HPP
 
-#include <memory>
 #include "serialPort/SerialPort.h"
 #include "unitreeMotor/unitreeMotor.h"
+#include <memory>
 
 namespace layered_hardware_unitree {
 
 struct UnitreeActuatorData {
-  UnitreeActuatorData(const std::string &_name, SerialPort *const _serial,
-                      const std::uint8_t _id, const MotorType &_motor_type, 
-                      const std::vector<double> &_torque_limits, const int &_temp_limit,
-                      const double &_pos_gain, const double &_vel_gain)
-      : name(_name), m_cmd(), m_data(), serial(_serial), id(_id),
-        torque_limits(_torque_limits), 
-        motor_type(_motor_type), temp_limit(_temp_limit),
-        pos_gain(_pos_gain), vel_gain(_vel_gain),
-        pos(0.), vel(0.), eff(0.), temperature(0), pos_cmd(0.), vel_cmd(0.), eff_cmd(0.) {
-    // initialize motor command & state
-    m_cmd.motorType = motor_type;
-    m_cmd.mode = queryMotorMode(motor_type, MotorMode::BRAKE);
-    m_cmd.id = id;
-
-    // Torque Off
-    m_cmd.tau = 0.;
-    m_cmd.dq = 0.;
-    m_cmd.q = 0.;
-    m_cmd.kp = 0.;
-    m_cmd.kd = 0.;
-
-    m_data.motorType = motor_type;
-  }
-
+  UnitreeActuatorData(const std::string &_name, SerialPort *const _serial, const std::uint8_t _id,
+                      const MotorType &_motor_type, const std::vector< double > &_torque_limits,
+                      const int &_temp_limit, const double &_pos_gain, const double &_vel_gain)
+      : name(_name), serial(_serial), id(_id), torque_limits(_torque_limits),
+        motor_type(_motor_type), temp_limit(_temp_limit), pos_gain(_pos_gain), vel_gain(_vel_gain),
+        pos(0.), vel(0.), eff(0.), temperature(0), pos_cmd(0.), vel_cmd(0.), eff_cmd(0.) {}
 
   // handles
   const std::string name;
-  MotorCmd m_cmd;
-  MotorData m_data;
   SerialPort *const serial;
   const std::uint8_t id;
 
   // params
   MotorType motor_type;
   const int temp_limit;
-  const std::vector<double> torque_limits;
+  const std::vector< double > torque_limits;
   const double pos_gain, vel_gain;
 
   // states

--- a/include/layered_hardware_unitree/velocity_mode.hpp
+++ b/include/layered_hardware_unitree/velocity_mode.hpp
@@ -2,108 +2,52 @@
 #define LAYERED_HARDWARE_UNITREE_VELOCITY_MODE_HPP
 
 #include <cmath>
-#include <cstdint>
-#include <limits>
-#include <map>
-#include <string>
 
-#include <layered_hardware_unitree/common_namespaces.hpp>
-#include <layered_hardware_unitree/unitree_actuator_data.hpp>
 #include <layered_hardware_unitree/operating_mode_base.hpp>
+#include <layered_hardware_unitree/unitree_actuator_data.hpp>
 #include <ros/duration.h>
 #include <ros/time.h>
-
-#include <ros/duration.h>
-#include <ros/time.h>
-
-#include <boost/optional.hpp>
-
 
 namespace layered_hardware_unitree {
+
 class VelocityMode : public OperatingModeBase {
 public:
-  VelocityMode(const UnitreeActuatorDataPtr &data) 
-      : OperatingModeBase("velocity", data) {}
-    
-  virtual void starting() override {
-    data_->m_cmd.kd = 0.01;
-    setFOCMode();
-    sendRecv();
-    readAllStates();
+  VelocityMode(const UnitreeActuatorDataPtr &data) : OperatingModeBase("velocity", data) {}
 
-    data_->vel_cmd = data_->vel;
-    prev_vel_cmd_ = std::numeric_limits< double >::quiet_NaN();    
+  virtual void starting() override {
+    // nothing to do
   }
 
   virtual void read(const ros::Time &time, const ros::Duration &period) override {
-    // read pos, vel, eff, temp
-    readAllStates();
+    // nothing to do as state variables will be updated in write()
   }
 
   virtual void write(const ros::Time &time, const ros::Duration &period) override {
-    // write goal position if the goal pos or profile velocity have been updated
-    // to make the change affect
-
-    bool is_limit = false;
-
-    // torque limit -------------------------------------------------------------
-    // If the torque limit is set and no stop command is currently provided
-    if (hasTorqueLimit() && !is_stopping_) {
-      // If the torque limit trigger is exceeded
-      if (data_->torque_limits[0] < abs(data_->eff)) {
-        // Change the scale of the speed command value given to the motor for each 
-        // limit between the current torque value and each limit set
-        for (int i = 1; i < data_->torque_limits.size(); i++) {
-          const int n_limits = data_->torque_limits.size() - 1;
-          if (data_->torque_limits[i-1] < abs(data_->eff) && abs(data_->eff) < data_->torque_limits[i]) {
-            double scale = (1 / n_limits) / (data_->torque_limits[i-1] - data_->torque_limits[i]) 
-                            * (abs(data_->eff) - data_->torque_limits[i-1]) + (n_limits - i + 1) / n_limits;
-            setVelocity(data_->vel_cmd * scale);
-            break;
-          } 
-        }
-
-        if (data_->torque_limits.back() < abs(data_->eff)) {
-          setVelocity(0.);
-        }
-        is_limit = true;
-      }    
-    }
-    // --------------------------------------------------------------------------
-
-    // temperature limit --------------------------------------------------------
-    // if over the temperature limit, stop the motor
-    if (data_->temp_limit < data_->temperature && hasTemperatureLimit()) {
-      setVelocity(0.);
-      is_limit = true;
-    }
-    // --------------------------------------------------------------------------
-
-    const bool do_write_vel(!std::isnan(data_->vel_cmd) &&
-                            data_->vel_cmd != prev_vel_cmd_ &&
-                            !is_limit);
-    if (do_write_vel) {
-
-      if (data_->vel_cmd == 0 && !is_stopping_) {
-        setPosition(data_->pos);
-        is_stopping_ = true;
-      }
-      else {
-        setVelocity(data_->vel_cmd);
-        is_stopping_ = false;
-      }
-    }
-
-    sendRecv();
-    prev_vel_cmd_ = data_->vel_cmd;
+    const float ratio = queryGearRatio(data_->motor_type);
+    // build motor command
+    // (if command is NaN, use 0 instead)
+    MotorCmd cmd = initializedMotorCmd(data_->motor_type, data_->id, MotorMode::FOC);
+    cmd.kd = data_->vel_gain;
+    cmd.dq = (!std::isnan(data_->vel_cmd) ? data_->vel_cmd : 0.) * ratio;
+    // build motor state data
+    MotorData data = initializedMotorData(data_->motor_type);
+    // send command & receive state
+    data_->serial->sendRecv(&cmd, &data);
+    // TODO: check data.merror here
+    // update state variables
+    data_->eff = data.tau;
+    data_->vel = data.dq / ratio;
+    data_->pos = data.q / ratio;
   }
 
-  virtual void stopping() override { torqueOff(); }
-
-private:
-  double prev_vel_cmd_;
-  bool is_stopping_;
+  virtual void stopping() override {
+    // disable torque by sending zero command
+    MotorCmd cmd = initializedMotorCmd(data_->motor_type, data_->id, MotorMode::FOC);
+    MotorData data = initializedMotorData(data_->motor_type);
+    data_->serial->sendRecv(&cmd, &data);
+  }
 };
-}
+
+} // namespace layered_hardware_unitree
 
 #endif

--- a/include/layered_hardware_unitree/velocity_mode.hpp
+++ b/include/layered_hardware_unitree/velocity_mode.hpp
@@ -15,7 +15,7 @@ public:
   VelocityMode(const UnitreeActuatorDataPtr &data) : OperatingModeBase("velocity", data) {}
 
   virtual void starting() override {
-    // nothing to do
+    data_->vel_cmd = 0.;
   }
 
   virtual void read(const ros::Time &time, const ros::Duration &period) override {

--- a/include/layered_hardware_unitree/velocity_mode.hpp
+++ b/include/layered_hardware_unitree/velocity_mode.hpp
@@ -38,6 +38,7 @@ public:
     data_->eff = data.tau;
     data_->vel = data.dq / ratio;
     data_->pos = data.q / ratio;
+    data_->temperature = data.temp;
   }
 
   virtual void stopping() override {


### PR DESCRIPTION
下記の点を改善してコードを整理しました．
* `unitree_actuator_sdk`を扱いやすくするためのユーティリティ関数の導入（`sdk_utils.hpp`）
* 上記ユーティリティを使用したPosition/Velocity/Torqueモードのリファクタ
* 旧VelocityモードをSafeVelocityモードに名称変更
* UnitreeActuatorData::{m_cmd, m_data}を不要にできたため，削除（モータに送るコマンドや受け取るデータは都度作成すればよく，使い回す必要はない．むしろ使い回しは元の状態が一貫しないため，バグの温床になる．）